### PR TITLE
Fix 'undefined index' warning in the pivot function of the array helper.

### DIFF
--- a/libraries/kextensions/array/array.php
+++ b/libraries/kextensions/array/array.php
@@ -212,7 +212,7 @@ class KextensionsArray
 		$result  = array();
 		$counter = array();
 
-		foreach ($source as $index => $value)
+		foreach ($source as $index => &$value)
 		{
 			// Determine the name of the pivot key, and its value.
 			if (is_array($value))
@@ -224,7 +224,7 @@ class KextensionsArray
 				}
 
 				$resultKey   = $value[$key];
-				$resultValue = & $source[$index];
+				$resultValue = &$value;
 			}
 			elseif (is_object($value))
 			{
@@ -235,7 +235,7 @@ class KextensionsArray
 				}
 
 				$resultKey   = $value->$key;
-				$resultValue = & $source[$index];
+				$resultValue = $value;
 			}
 			else
 			{


### PR DESCRIPTION
This bug is related to https://bugs.php.net/bug.php?id=66173 and to a strange
behaviour which also can be seen here https://3v4l.org/tofaS .
In short words: We shouldn't use numeric object properties at all, because they
start to act crazy if cast to an array. This commit fixes at least the pivot function,
a better fix would be to refactor the whole FAF workflow to not use numeric properties,
but this is too much work for the moment.
